### PR TITLE
Add "files" key to package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+examples/
+karma.conf.js
+test.js


### PR DESCRIPTION
I only listed `index.js`, because according to https://docs.npmjs.com/files/package.json:

> Certain files are always included, regardless of settings:
> - package.json
> - README (and its variants)
> - CHANGELOG (and its variants)
> - LICENSE / LICENCE

(closes #6)