### PR TITLE
Remove unnecessary `bind` on `keydown` handler

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -41,14 +41,14 @@ export default class ReactModal2 extends React.Component {
   componentDidMount() {
     if (ExecutionEnvironment.canUseDOM) {
       setFocusOn(ReactModal2.getApplicationElement(), this.refs.modal);
-      document.addEventListener('keydown', this.handleDocumentKeydown.bind(this));
+      document.addEventListener('keydown', this.handleDocumentKeydown);
     }
   }
 
   componentWillUnmount() {
     if (ExecutionEnvironment.canUseDOM) {
       resetFocus(ReactModal2.getApplicationElement());
-      document.removeEventListener('keydown', this.handleDocumentKeydown.bind(this));
+      document.removeEventListener('keydown', this.handleDocumentKeydown);
     }
   }
 


### PR DESCRIPTION
`bind` creates a new function so the `keydown` handler is not actually removed on `componentWillUnmount`. And since `handleDocumentKeydown` is an arrow function `bind` is not actually necessary.