### PR TITLE
Add React 15.0.0 support; use peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
   "dependencies": {
     "a11y-focus-scope": "^1.1.0",
     "a11y-focus-store": "^1.0.0",
-    "exenv": "^1.2.0",
-    "react": "^0.14.2"
+    "exenv": "^1.2.0"
+  },
+  "peerDependencies": {
+    "react": "^0.14.2 || ^15.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.1.1",


### PR DESCRIPTION
With React as a direct dependency, trying to upgrade to React 15.0.0 created a package tree something like this:

```
+-- react@15.0.0
+-- react-modal2@3.0.1
  `-- react@0.14.8
```

Having two copies of React causes problems. Switching to `peerDependencies` will prevent such problems on future upgrades and (from what I can tell) is the standard approach to specifying a dependency on React. (See [react-redux](https://github.com/reactjs/react-redux/blob/master/package.json) for an example.)