### PR TITLE
Update refs to callbacks for Fiber compat

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -40,7 +40,7 @@ export default class ReactModal2 extends React.Component {
 
   componentDidMount() {
     if (ExecutionEnvironment.canUseDOM) {
-      setFocusOn(ReactModal2.getApplicationElement(), this.refs.modal);
+      setFocusOn(ReactModal2.getApplicationElement(), this.modal);
       document.addEventListener('keydown', this.handleDocumentKeydown);
     }
   }
@@ -70,11 +70,11 @@ export default class ReactModal2 extends React.Component {
 
   render() {
     return (
-      <div ref="backdrop"
+      <div ref={i => this.backdrop = i}
         className={this.props.backdropClassName}
         style={this.props.backdropStyles}
         onClick={this.handleBackdropClick}>
-        <div ref="modal"
+        <div ref={i => this.modal = i}
           className={this.props.modalClassName}
           style={this.props.modalStyles}
           onClick={this.handleModalClick}

--- a/test/index.js
+++ b/test/index.js
@@ -48,7 +48,7 @@ describe('ReactModal2', function() {
     var dom = <ReactModal2 onClose={onClose}/>;
     var instance = ReactDOM.render(dom, this.root);
 
-    TestUtils.Simulate.click(instance.refs.backdrop);
+    TestUtils.Simulate.click(instance.backdrop);
 
     expect(called).to.be.true;
   });
@@ -60,7 +60,7 @@ describe('ReactModal2', function() {
     var dom = <ReactModal2 onClose={onClose} closeOnBackdropClick={false}/>;
     var instance = ReactDOM.render(dom, this.root);
 
-    TestUtils.Simulate.click(instance.refs.backdrop);
+    TestUtils.Simulate.click(instance.backdrop);
 
     expect(called).to.be.false;
   });
@@ -72,7 +72,7 @@ describe('ReactModal2', function() {
     var dom = <ReactModal2 onClose={onClose}/>;
     var instance = ReactDOM.render(dom, this.root);
 
-    TestUtils.Simulate.click(instance.refs.modal);
+    TestUtils.Simulate.click(instance.modal);
 
     expect(called).to.be.false;
   });
@@ -85,7 +85,7 @@ describe('ReactModal2', function() {
     var dom = <ReactModal2 onClose={function() {}}/>;
     var instance = ReactDOM.render(dom, this.root);
 
-    expect(instance.refs.modal).to.equal(document.activeElement);
+    expect(instance.modal).to.equal(document.activeElement);
 
     document.body.removeChild(input);
   });


### PR DESCRIPTION
Out of the box, when running a jest snapshot with React 16 alpha, I got this error:

```
TypeError: getStackAddendumByWorkInProgressFiber is not a function

      at captureError (../node_modules/react-test-renderer/lib/ReactFiberScheduler.js:889:29)
      at commitAllWork (../node_modules/react-test-renderer/lib/ReactFiberScheduler.js:400:9)
      at completeUnitOfWork (../node_modules/react-test-renderer/lib/ReactFiberScheduler.js:522:11)
      at performUnitOfWork (../node_modules/react-test-renderer/lib/ReactFiberScheduler.js:546:14)
      at workLoop (../node_modules/react-test-renderer/lib/ReactFiberScheduler.js:666:26)
      at performWork (../node_modules/react-test-renderer/lib/ReactFiberScheduler.js:707:30)
      at scheduleUpdate (../node_modules/react-test-renderer/lib/ReactFiberScheduler.js:1060:15)
      at scheduleTopLevelUpdate (../node_modules/react-test-renderer/lib/ReactFiberReconciler.js:60:5)
      at Object.updateContainer (../node_modules/react-test-renderer/lib/ReactFiberReconciler.js:90:7)
      at Object.create (../node_modules/react-test-renderer/lib/ReactTestRendererFiber.js:237:18)
```

This PR mitigates this error by replacing all string refs with callbacks.